### PR TITLE
Merged unnecessary run commands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.6
 COPY . /app/nhl-twitter-bot
 COPY resources /app/nhl-twitter-bot/resources/
-RUN pip install --upgrade wheel
-RUN pip install --upgrade setuptools
-RUN pip install -qr /app/nhl-twitter-bot/requirements.txt
+RUN pip install --upgrade wheel && \
+    pip install --upgrade setuptools && \
+    pip install -qr /app/nhl-twitter-bot/requirements.txt
 CMD [ "python" , "/app/nhl-twitter-bot/hockey_twitter_bot.py", "--docker" ]


### PR DESCRIPTION
Hi Matt - this isn't the most necessary change in the world, but it is considered a best practice to chain together one run command, rather than use multiple. The reason is, it keeps the docker image smaller - every run command creates a new layer, which increases image size.

Probably not a huge consideration - your image is going to be pretty small either way, so feel free to discard this PR if it doesn't suit you.