### PR TITLE
Fixes Next Game Issue

### DIFF
--- a/hockeygamebot/core/final.py
+++ b/hockeygamebot/core/final.py
@@ -63,7 +63,7 @@ def final_score(livefeed: dict, game: Game):
 
     # Using the NHL Schedule API, get the next game which goes at the bottom of this core tweet
     try:
-        next_game = schedule.get_next_game(game.preferred_team.team_id)
+        next_game = schedule.get_next_game(game.date_time_dt, game.preferred_team.team_id)
 
         # Caclulate the game in the team's local time zone
         tz_id = dateutil.tz.gettz(game.preferred_team.tz_id)

--- a/hockeygamebot/models/game.py
+++ b/hockeygamebot/models/game.py
@@ -41,6 +41,7 @@ class Game:
         self.game_id = game_id
         self.game_type = game_type
         self.date_time = date_time
+        self.date_time_dt = datetime.strptime(self.date_time, "%Y-%m-%dT%H:%M:%SZ")
         self.game_state = game_state
         self.venue = venue
         self.live_feed_endpoint = live_feed

--- a/hockeygamebot/nhlapi/schedule.py
+++ b/hockeygamebot/nhlapi/schedule.py
@@ -151,26 +151,29 @@ def get_broadcasts(resp):
     return broadcasts
 
 
-def get_next_game(team_id: int) -> dict:
-    """ Takes a team ID & gets the next game from the schedule API modified endpoint.
+def get_next_game(today_game_date: datetime, team_id: int) -> dict:
+    """ Takes today's game date & the team ID to get the next game from the NHL API endpoint.
 
     Args:
+        today_game_date (datetime) - The date of today's game.
         team_id (int) - The unique identifier of the team (from get_team function).
 
     Returns:
         next_game (dict) - Dictionary of next game attributes.
     """
 
+    tomorrow = (today_game_date + timedelta(days=1)).strftime("%Y-%m-%d")
+    end_date = (today_game_date + timedelta(days=365)).strftime("%Y-%m-%d")
+
     logging.info("Checking the schedule API endpoint for the next game.")
-    url = f"teams/{team_id}?expand=team.schedule.next"
+    url = f"schedule?teamId={team_id}&startDate={tomorrow}&endDate={end_date}"
 
     response = api.nhl_api(url)
     if not response:
         return None
 
     next_game_json = response.json()
-    next_game_sched = next_game_json.get("teams")[0].get("nextGameSchedule")
-    next_game = next_game_sched.get("dates")[0].get("games")[0]
+    next_game = next_game_json.get('dates')[0].get('games')[0]
 
     return next_game
 


### PR DESCRIPTION
Fixes an issue where the *next game* in the final chart tweet would show the same game as the one that is currently being played. Switches that function to the actual schedule endpoint.