### PR TITLE
Penalty Secondary Type Fix

### DIFF
--- a/hockeygamebot/models/gameevent.py
+++ b/hockeygamebot/models/gameevent.py
@@ -1291,6 +1291,11 @@ class PenaltyEvent(GenericEvent):
         self.minutes = results.get("penaltyMinutes")
         self.penalty_length_ss = 60 * self.minutes
 
+        # If penalty secondaryType is 'minor' (seems to be a recent bug) - skip, dump & try again next loop
+        if self.secondary_type == "minor":
+            logging.warning("BAD Secondary Type Found: %s", results)
+            raise ValueError("A penalty can not have a secondary type of 'minor' - skip & try again.")
+
         # Assign Penalty Team
         self.penalty_team = data.get("team").get("name")
         if self.penalty_team == self.game.preferred_team.team_name:
@@ -1442,7 +1447,7 @@ class PenaltyEvent(GenericEvent):
             penalty_text_players = (
                 f"{self.penalty_on_name} takes a {self.minutes}-minute {self.severity} penalty"
                 f"{self.penalty_zone_text} for {self.secondary_type} and heads to the "
-                f"penalty box with  {self.period_time_remain} remaining in the {self.period_ordinal} period. "
+                f"penalty box with {self.period_time_remain} remaining in the {self.period_ordinal} period. "
                 # f"That's his {utils.ordinal(self.penalty_on_game_ttl)} penalty of the game. "
                 f"{penalty_text_skaters}"
             )

--- a/hockeygamebot/social/twitter.py
+++ b/hockeygamebot/social/twitter.py
@@ -123,7 +123,9 @@ def send_tweet(
             # If we have gotten this far, remove the URL from the tweet text.
             tweet_text = tweet_text.split("\n")[0]
             tweet_text = f"@{twitter_handle} {tweet_text}"
-            status = twython_api.update_status(status=tweet_text, media_ids=[upload_response["media_id"]])
+            status = twython_api.update_status(
+                status=tweet_text, in_reply_to_status_id=reply, media_ids=[upload_response["media_id"]]
+            )
             return status.get("id_str")
         except Exception as e:
             logging.error("There was an error uploading and sending the embedded video - send with a link.")


### PR DESCRIPTION
Fixes an issue where the NHL would post a penalty too quickly and the `secondaryType` field would be **Minor** which makes the tweet read horribly. This fixes this by throwing a `ValueError` if it finds that text in that field and then waits for the NHL to fix it.

```
{
  "event": "Penalty",
  "eventCode": "CBJ542",
  "eventTypeId": "PENALTY",
  "description": "Seth Jones Minor",
  "secondaryType": "Minor",
  "penaltySeverity": "Minor",
  "penaltyMinutes": 2
}
```

Also fixes a tiny issue where the new embedded highlight videos wouldn't thread correctly because I forgot to add the `in_reply_to_status_id` argument in the **Twython** code.